### PR TITLE
chore(rinkeby/deployed.json): deploy ArcxTokenV2 on rinkeby

### DIFF
--- a/deployments/rinkeby/deployed.json
+++ b/deployments/rinkeby/deployed.json
@@ -337,5 +337,15 @@
     "version": 1,
     "type": "global",
     "group": ""
+  },
+  {
+    "name": "ArcxToken",
+    "source": "ArcxTokenV2",
+    "address": "0x5150d88Cd8b5159530532C9d90cFc0E36D0d3898",
+    "txn": "0xfabd353f4c5683dfb1307751023e369707c29bffcf4cd300df9c354d2bea2794",
+    "network": "rinkeby",
+    "version": 2,
+    "type": "global",
+    "group": ""
   }
 ]


### PR DESCRIPTION
Also transferred ownership of old arcx token to the new on rinkeby