### PR TITLE
chore: add exports required for sapphire

### DIFF
--- a/src/MerkleTree/index.ts
+++ b/src/MerkleTree/index.ts
@@ -1,0 +1,3 @@
+export * from './BalanceTree'
+export * from './CreditScoreTree'
+export * from './MerkleTree'

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,6 @@ export * from './SpritzArc';
 export * from './MozartArc';
 export * from './SpritzTestArc';
 export * from './constants';
+export * from './MerkleTree'
+export * from './utils'
 export { approve } from './utils/approve';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './getScoreProof'


### PR DESCRIPTION
To allow for the following imports in sapphire:
```
import { CreditScoreTree, CreditScore, getScoreProof } from '@arcxgame/contracts/dist/src'
```