### PR TITLE
Prevent users from using others' credit score proof

### DIFF
--- a/test/contracts/sapphire/borrow.test.ts
+++ b/test/contracts/sapphire/borrow.test.ts
@@ -372,9 +372,7 @@ describe('SapphireCore.borrow()', () => {
         undefined,
         scoredMinter,
       ),
-    ).to.be.revertedWith(
-      'SapphireCoreV1: the score proof does not match the caller',
-    );
+    ).to.be.revertedWith('SapphireCoreV1: proof.account must match msg.sender');
   });
 
   it('should not borrow more if more interest has accrued', async () => {

--- a/test/contracts/sapphire/liquidate.test.ts
+++ b/test/contracts/sapphire/liquidate.test.ts
@@ -554,7 +554,7 @@ describe('SapphireCore.liquidate()', () => {
           signers.liquidator,
         ),
       ).to.be.revertedWith(
-        'SapphireAssessor: proof should be provided for credit score',
+        'SapphireCoreV1: proof.account does not match the user to liquidate',
       );
     });
 
@@ -606,7 +606,7 @@ describe('SapphireCore.liquidate()', () => {
           signers.liquidator,
         ),
       ).to.be.revertedWith(
-        'SapphireCoreV1: credit score proof does not match the owner',
+        'SapphireCoreV1: proof.account does not match the user to liquidate',
       );
     });
 

--- a/test/contracts/sapphire/withdraw.test.ts
+++ b/test/contracts/sapphire/withdraw.test.ts
@@ -327,9 +327,7 @@ describe('SapphireCore.withdraw()', () => {
         undefined,
         signers.scoredMinter,
       ),
-    ).to.be.revertedWith(
-      `SapphireCoreV1: the credit score proof does not match the caller's address`,
-    );
+    ).to.be.revertedWith(`SapphireCoreV1: proof.account must match msg.sender`);
   });
 
   it('reverts if vault is undercollateralized', async () => {


### PR DESCRIPTION
This PR fixes the issue **QSP-1 Missing Proof Authentication** reported by Quantstamp where someone could just pass any proof they wanted