### PR TITLE
Add IERC20Metadata from OpenZeppelin

### DIFF
--- a/contracts/debt/sapphire/SapphireCoreV1.sol
+++ b/contracts/debt/sapphire/SapphireCoreV1.sol
@@ -5,6 +5,7 @@ pragma experimental ABIEncoderV2;
 
 import {BaseERC20} from "../../token/BaseERC20.sol";
 import {IERC20} from "../../token/IERC20.sol";
+import {IERC20Metadata} from "../../token/IERC20Metadata.sol";
 import {SafeERC20} from "../../lib/SafeERC20.sol";
 import {SafeMath} from "../../lib/SafeMath.sol";
 import {Math} from "../../lib/Math.sol";
@@ -146,7 +147,7 @@ contract SapphireCoreV1 is SapphireCoreStorage, Adminable {
         pauseOperator = _pauseOperator;
         feeCollector = _feeCollector;
 
-        BaseERC20 collateral = BaseERC20(collateralAsset);
+        IERC20Metadata collateral = IERC20Metadata(collateralAsset);
         uint8 collateralDecimals = collateral.decimals();
 
         require(

--- a/contracts/token/BaseERC20.sol
+++ b/contracts/token/BaseERC20.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.5.16;
 
 import {SafeMath} from "../lib/SafeMath.sol";
 
-import {IERC20} from "./IERC20.sol";
+import {IERC20Metadata} from "./IERC20Metadata.sol";
 import {Permittable} from "./Permittable.sol";
 
 /**
@@ -12,7 +12,7 @@ import {Permittable} from "./Permittable.sol";
  *
  * Basic ERC20 Implementation
  */
-contract BaseERC20 is IERC20, Permittable {
+contract BaseERC20 is IERC20Metadata, Permittable {
 
     using SafeMath for uint256;
 

--- a/contracts/token/IERC20Metadata.sol
+++ b/contracts/token/IERC20Metadata.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.5.16;
+
+import {IERC20} from "./IERC20.sol";
+
+/**
+ * @dev Interface for the optional metadata functions from the ERC20 standard.
+ *
+ * _Available since v4.1._
+ */
+contract IERC20Metadata is IERC20 {
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() external view returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token.
+     */
+    function symbol() external view returns (string memory);
+
+    /**
+     * @dev Returns the decimals places of the token.
+     */
+    function decimals() external view returns (uint8);
+}


### PR DESCRIPTION
Fixes QSP-26 from the audit﻿

![image](https://user-images.githubusercontent.com/5834876/121925233-b4b41580-cd0a-11eb-9af5-015185825d6d.png)
