### PR TITLE
Rename variable as recommended by Quantstamp

### DIFF
--- a/contracts/debt/sapphire/SapphireCoreV1.sol
+++ b/contracts/debt/sapphire/SapphireCoreV1.sol
@@ -996,8 +996,8 @@ contract SapphireCoreV1 is SapphireCoreStorage, Adminable {
         // --- EFFECTS ---
 
         // Get the liquidation price of the asset (discount for liquidator)
-        uint256 liquidationPricePercent = BASE.sub(liquidationUserFee);
-        uint256 liquidationPrice = Math.roundUpMul(_currentPrice, liquidationPricePercent);
+        uint256 liquidationPriceRatio = BASE.sub(liquidationUserFee);
+        uint256 liquidationPrice = Math.roundUpMul(_currentPrice, liquidationPriceRatio);
 
         // Calculate the amount of collateral to be sold based on the entire debt
         // in the vault


### PR DESCRIPTION
To fix the Adherence to Best Pracices #10:
![image](https://user-images.githubusercontent.com/5834876/122142541-b8848c80-ce1d-11eb-960a-cf3645984446.png)

> There is no issue with the code itself, it is just with the comments. The reason is that a percentage is a number between 0 and 100, so these variables you refer to as a percentage with 18 decimal places are likely to be understood by people new to the code (such as ourselves) as numbers between 0 and 100*10**18 = 10**20. We recommend you to use the term ratio instead, as a ratio would be a number between 0 and 1 (the version with decimals being between 0 and 10**18) and that would be more in line with how the code operates.
> `- Luís from Quantstamp`