### PR TITLE
refactor: adapt type

### DIFF
--- a/deployments/src/loadContracts.ts
+++ b/deployments/src/loadContracts.ts
@@ -12,7 +12,7 @@ export interface LoadContractParams {
   source?: string;
   type?: string;
   group?: string;
-  version?: number;
+  version?: number | string;
 }
 
 export interface ContractDetails {


### PR DESCRIPTION
https://app.asana.com/0/1200654815768576/1201080629206183
Relates to https://github.com/arcxmoney/monorepo/pull/816

This is needed because the `version` property of `DefiPassport` in
contracts/deployments/mainnet/deployed.json` is of type string