### PR TITLE
Update starcx contract deployment on rinkeby

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,6 +1,6 @@
 {
   "hooks": {
     "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-    "pre-commit": "yarn run lint:sol"
+    "pre-commit": "yarn run lint:sol && yarn run lint:ts"
   }
 }

--- a/deployments/rinkeby/deployed.json
+++ b/deployments/rinkeby/deployed.json
@@ -701,8 +701,8 @@
   {
     "name": "StakingAccrualERC20",
     "source": "StakingAccrualERC20V5",
-    "address": "0x6f1DFe0Ca0d344cca8fBdAf06C3b800b2C37d801",
-    "txn": "0x7fadd60aa348d9c9158ac237efc9d3a959f17590a1c222d85dc4ddbf47140d7e",
+    "address": "0xC16d23d4372696E244bd00E21e5B324a90f56bb4",
+    "txn": "0x39a130bca2d94d9ba2d2eda0a52eaa76fd79d66e7386271dd160ab2418d2a50b",
     "network": "rinkeby",
     "version": 5,
     "type": "global",

--- a/test/distributor/MerkleDistributor.test.ts
+++ b/test/distributor/MerkleDistributor.test.ts
@@ -19,7 +19,7 @@ describe('MerkleDistributor', () => {
   let distributor: MerkleDistributor;
 
   before(async () => {
-    ctx = await generateContext(distributorFixture, async () => {});
+    ctx = await generateContext(distributorFixture, async () => null);
     distributor = await deployMerkleDistributor(
       ctx.signers.admin,
       ctx.contracts.collateral.address,


### PR DESCRIPTION
Had to do this because the contract in this repo didn't quite reflect what was deployed on chain. That's because I renamed the `what` variable to `tokensToTransfer` etc﻿
