### PR TITLE
Fix deposited asset calculation bug

### DIFF
--- a/contracts/sapphire/SapphirePool/SapphirePool.sol
+++ b/contracts/sapphire/SapphirePool/SapphirePool.sol
@@ -690,7 +690,7 @@ contract SapphirePool is
             // The withdraw amount is bigger than the user's initial deposit. This happens when the
             // rewards claimable by the user are greater than the amount of tokens they have
             // deposited.
-            if (info.assetUtilization > info.userDeposit) {
+            if (info.scaledAssetUtilization > info.userDeposit) {
                 // There's more asset utilization than the user's initial deposit. Reduce it by
                 // the amount of the user's initial deposit.
                 return (


### PR DESCRIPTION
There was a minor bug in the contract where every time someone withdrew more than they deposited, the asset deposit limit would be set to zero because of a scaling bug. This PR fixes this.

EDIT: this bug also caused lenders to be unable to withdraw their deposits, in some edge case.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202179828277078
  - https://app.asana.com/0/0/1202194356888166