### PR TITLE
Set type of SapphireArc collateral to BaseERC20

### DIFF
--- a/arc-types/core.ts
+++ b/arc-types/core.ts
@@ -1,11 +1,10 @@
-import { SapphireAssessor, SapphirePool } from '@src/typings';
-import { IERC20 } from '@src/typings/IERC20';
+import { BaseERC20, SapphireAssessor, SapphirePool } from '@src/typings';
 import { ISapphireOracle } from '@src/typings/ISapphireOracle';
 
 export type CoreContracts<T> = {
   core: T;
   oracle: ISapphireOracle;
-  collateral: IERC20;
+  collateral: BaseERC20;
   pool: SapphirePool;
   assessor: SapphireAssessor;
 };


### PR DESCRIPTION
The collateral is always a BaseERC20, so this change will allow us to skip an extra casting if we want to get `decimals()`, for example
