### PR TITLE
Support single leaf trees in Sapphire core

### DIFF
--- a/contracts/lib/PassportScoreVerifiable.sol
+++ b/contracts/lib/PassportScoreVerifiable.sol
@@ -33,9 +33,8 @@ contract PassportScoreVerifiable {
             );
         }
 
-        bool isProofPassed = _scoreProof.merkleProof.length > 0;
 
-        if (_isScoreRequired || isProofPassed || _scoreProof.score > 0) {
+        if (_isScoreRequired || _scoreProof.score > 0) {
             passportScoresContract.verify(_scoreProof);
         }
         _;

--- a/contracts/sapphire/SapphireAssessor.sol
+++ b/contracts/sapphire/SapphireAssessor.sol
@@ -95,12 +95,10 @@ contract SapphireAssessor is Ownable, ISapphireAssessor, PassportScoreVerifiable
             "SapphireAssessor: The lower bound must be smaller than the upper bound"
         );
 
-        bool isProofPassed = _scoreProof.merkleProof.length > 0;
-
         // If the proof is passed, use the score from the score proof since at this point
         // the proof should be verified if the score is > 0
         uint256 result = mapper.map(
-            isProofPassed ? _scoreProof.score : 0,
+            _scoreProof.score,
             maxScore,
             _lowerBound,
             _upperBound

--- a/test/contracts/sapphire/sapphirePassportScores.test.ts
+++ b/test/contracts/sapphire/sapphirePassportScores.test.ts
@@ -12,6 +12,7 @@ import { CREDIT_PROOF_PROTOCOL } from '@src/constants';
 import {
   addSnapshotBeforeRestoreAfterEach,
   advanceEpoch,
+  immediatelyUpdateMerkleRoot,
 } from '@test/helpers/testingUtils';
 import chai, { expect } from 'chai';
 import { solidity } from 'ethereum-waffle';
@@ -414,6 +415,26 @@ describe('SapphireCreditScore', () => {
         await passportScores
           .connect(unauthorized)
           .verify(getScoreProof(passportScore1, tree)),
+      ).to.be.true;
+    });
+
+    it('should verify a single leaf', async () => {
+      const singleLeafTree = new PassportScoreTree([passportScore1]);
+
+      await immediatelyUpdateMerkleRoot(
+        passportScores.connect(merkleRootUpdater),
+        singleLeafTree.getHexRoot(),
+      );
+
+      console.log('proof', getScoreProof(passportScore1, singleLeafTree));
+
+      expect(
+        await passportScores.verify({
+          account: passportScore1.account,
+          protocol: passportScore1.protocol,
+          score: passportScore1.score,
+          merkleProof: [],
+        }),
       ).to.be.true;
     });
 


### PR DESCRIPTION
Part of https://github.com/arcxmoney/data-lakehouse/issues/633

Single leaf trees are already supported by the `SapphirePassportScores`. However, the Sapphire cores don't support it because it considers a proof is passed only if `proof.length > 0`. In the case of a single leaf tree, the proof is empty, as the node hashed is the root itself.

With this PR's changes, the logic is not impacted, other than supporting single-leaf trees.
