### PR TITLE
Fix published package

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,7 @@
+{
+  "branches": [
+    "master",
+    "develop"
+  ],
+  "pkgRoot": "dist"
+}

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",
   "files": [
-    "dist/src/*",
-    "dist/arc-types/*",
-    "dist/deployments/*"
+    "src/*",
+    "arc-types/*",
+    "deployments/*"
   ],
   "author": "Kerman Kohli <kermankohli@gmail.com>",
   "license": "MIT",
@@ -21,7 +21,7 @@
     "test": "yarn hardhat test",
     "test:ci": "npx mocha --reporter mocha-junit-reporter --require ts-node/register --require tsconfig-paths/register --require hardhat/register --exit",
     "release": "yarn release:local && release-it",
-    "release:local": "rm -rf dist && ttsc && copyfiles -u 2 src/typings/*.d.ts dist/src/typings",
+    "release:local": "rm -rf dist && ttsc && copyfiles -u 2 src/typings/*.d.ts dist/src/typings && cp package.json dist",
     "commit": "git add . && cz"
   },
   "devDependencies": {


### PR DESCRIPTION
The current build on `master` is broken because instead of including the contents of `dist/`, it included `dist/` itself. This PR fixes that. Previously we always included the `dist/`folder, but that was a bad practice.
