### PR TITLE
ArcProxy: set admin before calling delegatecall()

### DIFF
--- a/contracts/ArcProxy.sol
+++ b/contracts/ArcProxy.sol
@@ -71,13 +71,6 @@ contract ArcProxy {
 
         _setImplementation(_logic);
 
-        if (_data.length > 0) {
-            /* solhint-disable-next-line */
-            (bool success,) = _logic.delegatecall(_data);
-            /* solhint-disable-next-line */
-            require(success);
-        }
-
         assert(
             ADMIN_SLOT == bytes32(
                 uint256(keccak256("eip1967.proxy.admin")) - 1
@@ -85,6 +78,13 @@ contract ArcProxy {
         );
 
         _setAdmin(admin_);
+
+        if (_data.length > 0) {
+            /* solhint-disable-next-line */
+            (bool success,) = _logic.delegatecall(_data);
+            /* solhint-disable-next-line */
+            require(success);
+        }
     }
 
     /**

--- a/test/contracts/global/arcProxy.test.ts
+++ b/test/contracts/global/arcProxy.test.ts
@@ -1,0 +1,46 @@
+import { ArcProxyFactory, SapphirePassportScoresFactory } from '@src/typings';
+import {} from '@test/helpers';
+import { expect } from 'chai';
+import { constants, utils } from 'ethers';
+import hre from 'hardhat';
+
+describe('ArcProxy', () => {
+  it('calls the init function of the target contract at deploy time', async () => {
+    const [signer] = await hre.ethers.getSigners();
+
+    const passportScoresImpl = await new SapphirePassportScoresFactory(
+      signer,
+    ).deploy();
+
+    const initSelector = passportScoresImpl.interface.getSighash(
+      passportScoresImpl.interface.functions[
+        'init(bytes32,address,address,uint256)'
+      ],
+    );
+    const encoder = new utils.AbiCoder();
+
+    const data = utils.solidityPack(
+      ['bytes4', 'bytes'],
+      [
+        initSelector,
+        encoder.encode(
+          ['bytes32', 'address', 'address', 'uint256'],
+          [constants.HashZero, signer.address, signer.address, 21],
+        ),
+      ],
+    );
+
+    const proxy = await new ArcProxyFactory(signer).deploy(
+      passportScoresImpl.address,
+      signer.address,
+      data,
+    );
+
+    const passport = SapphirePassportScoresFactory.connect(
+      proxy.address,
+      signer,
+    );
+    expect(await passport.getAdmin()).to.eq(signer.address);
+    expect(await passport.currentEpoch()).to.eq(21);
+  });
+});


### PR DESCRIPTION
As pointed out by a bug bounty hunter, the current implementation of `ArcProxy` reverts if we're trying to make a `delegatecall()` at deployment time. This is because the admin is set after the call rather than before. This PR fixes this.
